### PR TITLE
Fix noise and continuous repeats for Arduino-base media-players with home assistant TTS starting in 2025.4.0

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -84,9 +84,7 @@ size_t AudioBuffer::freeSpace() {
 }
 
 size_t AudioBuffer::writeSpace() {
-    if(m_readPtr == m_writePtr) {
-        m_writeSpace = 0;
-    } else if (m_readPtr > m_writePtr) {
+    if(m_readPtr >= m_writePtr) {
         m_writeSpace = (m_readPtr - m_writePtr - 1); // readPtr must not be overtaken
     } else {
         if(getReadPos() == 0)

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -84,7 +84,9 @@ size_t AudioBuffer::freeSpace() {
 }
 
 size_t AudioBuffer::writeSpace() {
-    if(m_readPtr >= m_writePtr) {
+    if(m_readPtr == m_writePtr) {
+        m_writeSpace = 0;
+    } else if (m_readPtr > m_writePtr) {
         m_writeSpace = (m_readPtr - m_writePtr - 1); // readPtr must not be overtaken
     } else {
         if(getReadPos() == 0)
@@ -3001,12 +3003,14 @@ void Audio::processWebStream() {
     const uint16_t  maxFrameSize = InBuff.getMaxBlockSize();    // every mp3/aac frame is not bigger
     static bool     f_stream;                                   // first audio data received
     static uint32_t chunkSize;                                  // chunkcount read from stream
+	static bool zeroSizeChunkFound;                             // signals end of data
 
     // first call, set some values to default  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     if(m_f_firstCall) { // runs only ont time per connection, prepare for start
         m_f_firstCall = false;
         f_stream = false;
         chunkSize = 0;
+		zeroSizeChunkFound = false;
         m_metacount = m_metaint;
         readMetadata(0, true); // reset all static vars
     }
@@ -3017,6 +3021,7 @@ void Audio::processWebStream() {
     if(m_f_chunked && availableBytes){
         uint8_t readedBytes = 0;
         if(!chunkSize) chunkSize = chunkedDataTransfer(&readedBytes);
+	    if(!chunkSize) zeroSizeChunkFound = true;    
         availableBytes = min(availableBytes, chunkSize);
     }
     // we have metadata  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3039,6 +3044,12 @@ void Audio::processWebStream() {
             InBuff.bytesWritten(bytesAddedToBuffer);
         }
 
+		if(m_f_chunked && !chunkSize) {
+			// Strip off the CRLF after each chunk, including the last one.
+            uint8_t readedBytes = 0;
+            (void)chunkedDataTransfer(&readedBytes);
+        }
+
         if(InBuff.bufferFilled() > maxFrameSize && !f_stream) {  // waiting for buffer filled
             f_stream = true;  // ready to play the audio data
             AUDIO_INFO("stream ready");
@@ -3050,7 +3061,13 @@ void Audio::processWebStream() {
     if(f_stream){
         static uint8_t cnt = 0;
         cnt++;
-        if(cnt == 3){playAudioData(); cnt = 0;}
+        if(cnt == 3){playAudioData(zeroSizeChunkFound); cnt = 0;}
+    }
+    
+    if (zeroSizeChunkFound && (InBuff.bufferFilled() == 0)) {
+    	_client->stop();
+    	playI2Sremains();
+    	stopSong();
     }
 }
 //---------------------------------------------------------------------------------------------------------------------
@@ -3417,9 +3434,12 @@ void Audio::processWebStreamHLS() {
     return;
 }
 //---------------------------------------------------------------------------------------------------------------------
-void Audio::playAudioData(){
 
-    if(InBuff.bufferFilled() < InBuff.getMaxBlockSize()) return; // guard
+void Audio::playAudioData(bool forcePlay){
+
+    if (!forcePlay) {
+        if(InBuff.bufferFilled() < InBuff.getMaxBlockSize()) return; // guard
+    }
 
     int bytesDecoded = sendBytes(InBuff.getReadPtr(), InBuff.getMaxBlockSize());
 

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -3008,14 +3008,12 @@ void Audio::processWebStream() {
     const uint16_t  maxFrameSize = InBuff.getMaxBlockSize();    // every mp3/aac frame is not bigger
     static bool     f_stream;                                   // first audio data received
     static uint32_t chunkSize;                                  // chunkcount read from stream
-	static bool zeroSizeChunkFound;                             // signals end of data
 
     // first call, set some values to default  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     if(m_f_firstCall) { // runs only ont time per connection, prepare for start
         m_f_firstCall = false;
         f_stream = false;
         chunkSize = 0;
-		zeroSizeChunkFound = false;
         m_metacount = m_metaint;
         readMetadata(0, true); // reset all static vars
     }
@@ -3080,14 +3078,9 @@ play:
     if(f_stream){
         static uint8_t cnt = 0;
         cnt++;
-        if(cnt == 3){playAudioData(zeroSizeChunkFound); cnt = 0;}
+        if(cnt == 3){playAudioData(); cnt = 0;}
     }
     
-    if (zeroSizeChunkFound && (InBuff.bufferFilled() == 0)) {
-    	_client->stop();
-    	playI2Sremains();
-    	stopSong();
-    }
 }
 //---------------------------------------------------------------------------------------------------------------------
 void Audio::processWebFile() {
@@ -3453,7 +3446,8 @@ void Audio::processWebStreamHLS() {
     return;
 }
 //---------------------------------------------------------------------------------------------------------------------
-void Audio::playAudioData(bool forcePlay){
+void Audio::playAudioData() {
+
     if(!InBuff.isPlayable()) return; // guard
 
     int bytesDecoded = sendBytes(InBuff.getReadPtr(), InBuff.getMaxBlockSize());

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -141,6 +141,7 @@ void AudioBuffer::resetBuffer() {
     m_endPtr = m_buffer + m_buffSize;
     m_f_start = true;
     // memset(m_buffer, 0, m_buffSize); //Clear Inputbuffer
+    m_complete = false;
 }
 
 uint32_t AudioBuffer::getWritePos() {
@@ -2396,6 +2397,12 @@ bool Audio::playChunk() {
 void Audio::loop() {
 
     if(!m_f_running) return;
+	
+    if(InBuff.isComplete() && InBuff.isEmpty()) {
+        playI2Sremains();
+        stopSong();
+        return;
+    }
 
     if(m_playlistFormat != FORMAT_M3U8){ // normal process
         switch(getDatamode()){
@@ -3014,12 +3021,22 @@ void Audio::processWebStream() {
     }
 
     if(getDatamode() != AUDIO_DATA) return;              // guard
+
     uint32_t availableBytes = _client->available();      // available from stream
+
+    if (InBuff.isComplete()) {
+        // We are waiting for the data to play out, so stop reading and keep writing.
+        goto play;
+    }
+
     // chunked data tramsfer - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     if(m_f_chunked && availableBytes){
         uint8_t readedBytes = 0;
         if(!chunkSize) chunkSize = chunkedDataTransfer(&readedBytes);
-	    if(!chunkSize) zeroSizeChunkFound = true;    
+        if(chunkSize == 0) {
+            // The buffer now contains the last chunk of data.
+            InBuff.setComplete();
+        }
         availableBytes = min(availableBytes, chunkSize);
     }
     // we have metadata  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3042,19 +3059,23 @@ void Audio::processWebStream() {
             InBuff.bytesWritten(bytesAddedToBuffer);
         }
 
-		if(m_f_chunked && !chunkSize) {
-			// Strip off the CRLF after each chunk, including the last one.
-            uint8_t readedBytes = 0;
-            (void)chunkedDataTransfer(&readedBytes);
+        if(m_f_chunked && (chunkSize == 0)) {
+            // Strip off the CRLF after each chunk.
+            if (!stripCRLF()) {
+                log_e("CRLF not found");
+                stopSong();
+                return;
+            }
         }
 
-        if(InBuff.bufferFilled() > maxFrameSize && !f_stream) {  // waiting for buffer filled
+        if(InBuff.isPlayable() && !f_stream) {  // waiting for buffer filled
             f_stream = true;  // ready to play the audio data
             AUDIO_INFO("stream ready");
         }
         if(!f_stream) return;
     }
 
+play:
     // play audio data - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     if(f_stream){
         static uint8_t cnt = 0;
@@ -3432,12 +3453,8 @@ void Audio::processWebStreamHLS() {
     return;
 }
 //---------------------------------------------------------------------------------------------------------------------
-
 void Audio::playAudioData(bool forcePlay){
-
-    if (!forcePlay) {
-        if(InBuff.bufferFilled() < InBuff.getMaxBlockSize()) return; // guard
-    }
+    if(!InBuff.isPlayable()) return; // guard
 
     int bytesDecoded = sendBytes(InBuff.getReadPtr(), InBuff.getMaxBlockSize());
 
@@ -5063,6 +5080,38 @@ uint16_t Audio::readMetadata(uint16_t maxBytes, bool first) {
     return res;
 }
 //----------------------------------------------------------------------------------------------------------------------
+bool Audio::stripCRLF(int prevChar) {
+    if (prevChar && (prevChar != '\r')) {
+        return false;
+    }
+    const uint32_t timeout = 2000; // ms
+    const uint32_t startTime = millis();
+    while(true) {
+        if((millis() - startTime) >= timeout) {
+            log_e("CRLF timeout");
+            return false;
+        }
+        if(_client->available() != 0) {
+            switch (_client->read()) {
+                case '\r':
+                    if(prevChar) {
+                        return false;
+                    }
+                    prevChar = '\r';
+                    break;
+                case '\n':
+                    return (prevChar == '\r');
+                    break;
+                default:
+                    return false;
+                    break;
+            }
+        } else {
+            delay(1); // wait for next byte
+        }
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 size_t Audio::chunkedDataTransfer(uint8_t* bytes){
     uint8_t byteCounter = 0;
     size_t chunksize = 0;

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -137,7 +137,10 @@ public:
     uint32_t getReadPos();                      // read position relative to the beginning
     void     resetBuffer();                     // restore defaults
     bool     havePSRAM() { return m_f_psram; };
-
+    void     setComplete() { m_complete = true; }; // indicates that the buffer contains the last data of a source
+    bool     isComplete() { return m_complete; }; // returns true if the buffer contains the last data of a source
+    bool     isEmpty() { return bufferFilled() == 0; }; // returns true if the buffer is empty
+    bool     isPlayable() { return isComplete() || (bufferFilled() >= m_maxBlockSize); }; // returns true if the buffer is either complete or has enough data to play
 protected:
     size_t   m_buffSizePSRAM    = 300000;   // most webstreams limit the advance to 100...300Kbytes
     size_t   m_buffSizeRAM      = 1600 * 5;
@@ -155,6 +158,7 @@ protected:
     bool     m_f_start          = true;
     bool     m_f_init           = false;
     bool     m_f_psram          = false;    // PSRAM is available (and used...)
+    bool     m_complete         = false;    // true if the buffer contains the last data from a source.    
 };
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -278,6 +282,7 @@ private:
 
 //+++ W E B S T R E A M  -  H E L P   F U N C T I O N S +++
     uint16_t readMetadata(uint16_t b, bool first = false);
+    bool     stripCRLF(int prevChar = 0);
     size_t   chunkedDataTransfer(uint8_t* bytes);
     bool     readID3V1Tag();
     void     slowStreamDetection(uint32_t inBuffFilled, uint32_t maxFrameSize);

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -234,7 +234,7 @@ private:
     void processWebFile();
     void processWebStreamTS();
     void processWebStreamHLS();
-    void playAudioData(bool forcePlay=false);
+    void playAudioData();
     bool readPlayListData();
     const char* parsePlaylist_M3U();
     const char* parsePlaylist_PLS();

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -230,7 +230,7 @@ private:
     void processWebFile();
     void processWebStreamTS();
     void processWebStreamHLS();
-    void playAudioData();
+    void playAudioData(bool forcePlay=false);
     bool readPlayListData();
     const char* parsePlaylist_M3U();
     const char* parsePlaylist_PLS();


### PR DESCRIPTION
A recent change in the home assistant core TTS component (2025.4.0+) has caused a problem with esphome I2S-based media-players for Arduino. https://esphome.io/projects/index.html

The HA core TTS component has changed to a HTTP chunked-response, perfectly valid,  which is not being parsed correctly in processWebStream() (in Audio.cpp near 3017). 

The parsing error results in some glitches in the sound, but more critically, it triggers lostStreamDetection() which reloads the speech stream 1-2 minutes later, repetitively.

The main problems with the method are not skipping the CRLF following each chunk, and not ending gracefully after the last chunk.

The MP3 files that are not chunk-encoded, use processWebFile() and work fine.


To reproduce the problem in HA: Click to the Media tab, then Text to Speech, then Google Translate, select the media player, enter a message and click "say".

This change was tested with HA 2025.3.3 which never had a problem, and HA 2025.4.0 where the problem was first seen.

The way that I tested is as follows:

1. Install the esphome builder, to a host machine (i.e. outside of HA) https://esphome.io/guides/installing_esphome.html
2. Create a new folder and save a copy of the mediaplayer .yaml and secrets.yaml. ex. mediaplayer1.yaml
3. Use "esphome compile mediaplayer1.yaml" to build. This downloads all the required libraries.
4. Find downloaded Audio.h and Audio.cpp. Look in ..esphome\build\mediaplayer1.piolibdeps\mediaplayer1\ESP32-audioI2S\src
5. Replace Audio.h and Audio.cpp with the ones that I changed.
6. Connect a media player directly to the host and determine the COM number.
7. Use "esphome run mediaplayer1.yaml" to download to the device. Choose the COM from a list.
8. Test as described in the issue. Media tab, etc.

I tested a short TTS message and I also copied a longer new article into TTS.

Aside from TTS, I also tried downloading a big .mp3 and playing some radio stations. The big .mp3 was fine but there were various results with the radio stations: one or two were fine, one had repeating dropouts and one causes the media to instantly crash. I went back to the original media player version and it was crashing as well.

I have the following media-player versions: 1 raspi, 2 atom, 2 ESP32 D1. All seem to be operating correctly for HA TTS which is the only purpose that I use them for.

User @MacrosorcH has tested as well, reporting:
> "...can confirm that it seems to work perfectly on my Raspiaudio Muse Luxe.
> No more TTS repeating, the media player goes back to idle as expected immediately after TTS playback, and the rest of audio sources seem to work just fine too (web radio, WAV, MP3, Music Assistant... no issues)."

I am new to this code, and to esphome, so I am looking for assistance to identify any issues that the change might cause.

Related Issues:
https://github.com/home-assistant/core/issues/142022
https://github.com/esphome/ESP32-audioI2S/issues/18
https://github.com/esphome/issues/issues/6925
https://github.com/esphome/issues/issues/6921



