### PR TITLE
increase limit on host length

### DIFF
--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -380,7 +380,7 @@ bool Audio::connecttohost(const char* host, const char* user, const char* pwd) {
 
     uint16_t lenHost = strlen(host);
 
-    if(lenHost >= 512 - 10) {
+    if(lenHost >= 1024 - 10) {
         AUDIO_INFO("Hostaddress is too long");
         return false;
     }

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -87,7 +87,7 @@ extern __attribute__((weak)) void audio_eof_stream(const char*); // The webstrea
 extern __attribute__((weak)) void audio_process_extern(int16_t* buff, uint16_t len, bool *continueI2S); // record audiodata or send via BT
 extern __attribute__((weak)) void audio_process_i2s(uint32_t* sample, bool *continueI2S); // record audiodata or send via BT
 
-#define AUDIO_INFO(...) {char buff[512 + 64]; sprintf(buff,__VA_ARGS__); if(audio_info) audio_info(buff);}
+#define AUDIO_INFO(...) {char buff[512 + 64]; snprintf(buff,sizeof(buff),__VA_ARGS__); if(audio_info) audio_info(buff);}
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -493,7 +493,7 @@ private:
 
     char*           m_chbuf = NULL;
     uint16_t        m_chbufSize = 0;                // will set in constructor (depending on PSRAM)
-    char            m_lastHost[512];                // Store the last URL to a webstream
+    char            m_lastHost[1024];                // Store the last URL to a webstream
     char*           m_playlistBuff = NULL;          // stores playlistdata
     const uint16_t  m_plsBuffEntryLen = 256;        // length of each entry in playlistBuff
     filter_t        m_filter[3];                    // digital filters


### PR DESCRIPTION
the ESP32-audioI2S in the version found in this fork limits the host length (= length of a playback url) to about 502 characters.
this causes issues when trying to play files using homeassistant, especially if the filename is a bit longer or the file is located in a directory structure. 

this PR introduces a change that mitigates this issue by increasing the limit to about 1014 characters, which should be enough for most files played from homeassistant.
additionally, to avoid hard-to-catch issues due to logging, the `AUDIO_INFO` macro was updated to use snprintf.
without this change, longer log lines (for example due to a longer url, but not limited to that) would likely cause memory corruption and crashes.

the PR partially (where applicable) backports changes from https://github.com/schreibfaul1/ESP32-audioI2S/commit/b1b89a9f64b73b0b171493bf55e6158f37a0bccd.
it is likely to fix https://github.com/esphome/issues/issues/4631 and fix https://github.com/esphome/ESP32-audioI2S/issues/11.

while a proper fix would be to update this fork, or switch the esphome dependency to the upstream repo (see https://github.com/esphome/esphome/pull/7348), this change will work to fix the issue just fine too - and will be easier to review and merge.


## Usage (in esphome)

use my fork of esphome that updates my ESP32-audioI2S fork as such:

```yaml
external_components:
  - source: github://shadow578/esphome@mediaplayer-increase-host-lenght
    components:
      - i2s_audio
      - media_player
      - i2s_audio/media_player
    refresh: 0s
```

then, use the media_player as normal







